### PR TITLE
fix: redundant type declaration for `INestApplication`

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -5,7 +5,7 @@ import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let app: INestApplication;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
noticed that the `INestApplication` type was being explicitly typed as `App`, but it’s unnecessary since `INestApplication` already serves as the complete type.